### PR TITLE
Доработан поиск по дате комментария или вопроса

### DIFF
--- a/app/frontend/controllers/SiteController.php
+++ b/app/frontend/controllers/SiteController.php
@@ -6,6 +6,7 @@ use App\Contact\Http\Action\V1\Contact\ContactAction;
 use App\forms\SearchForm;
 use App\Question\Entity\Statistic\QuestionStatsRepository;
 use App\Search\Http\Action\V1\SearchSettings\ToggleAction;
+use App\services\EmptySearchRequestExceptions;
 use App\services\ManticoreService;
 use Yii;
 use yii\web\Controller;
@@ -92,6 +93,7 @@ class SiteController extends Controller
         $this->layout = 'search';
         $results = null;
         $form = new SearchForm();
+        $errorQueryMessage = '';
 
         try {
             if ($form->load(Yii::$app->request->queryParams) && $form->validate()) {
@@ -100,11 +102,14 @@ class SiteController extends Controller
         } catch (\DomainException $e) {
             Yii::$app->errorHandler->logException($e);
             Yii::$app->session->setFlash('error', $e->getMessage());
+        } catch (EmptySearchRequestExceptions $e) {
+            $errorQueryMessage = $e->getMessage();
         }
 
         return $this->render('index', [
             'results' => $results ?? null,
             'model' => $form,
+            'errorQueryMessage' => $errorQueryMessage,
         ]);
     }
 

--- a/app/frontend/views/site/index.php
+++ b/app/frontend/views/site/index.php
@@ -1,9 +1,12 @@
 <?php
 
-/** @var yii\web\View $this */
-/** @var QuestionDataProvider $results */
-/** @var Pagination $pages */
-/** @var SearchForm $model */
+/**
+ * @var yii\web\View $this
+ * @var QuestionDataProvider $results
+ * @var Pagination $pages
+ * @var SearchForm $model
+ * @var string $errorQueryMessage
+ */
 
 use App\forms\SearchForm;
 use App\helpers\DateHelper;
@@ -36,14 +39,11 @@ $inputTemplate = '<div class="input-group mb-2">
           </button>
           </div>';
 
-//$this->title = 'Поиск по ФКТ';
 $this->params['breadcrumbs'][] = $this->title;
 ?>
   <div class="site-index">
     <div class="search-block">
       <div class="container-fluid">
-          <?php if (!$results): ?>
-          <?php endif; ?>
 
           <?php $form = ActiveForm::begin(
               [
@@ -113,7 +113,15 @@ $this->params['breadcrumbs'][] = $this->title;
           <?php ActiveForm::end(); ?>
       </div>
     </div>
+
       <div class="container-fluid search-results">
+          <?php if (!$results): ?>
+              <?php if ($errorQueryMessage): ?>
+                  <div class="card">
+                      <div class="card-body"><?= $errorQueryMessage; ?></div>
+                  </div>
+              <?php endif; ?>
+          <?php endif; ?>
           <?php if ($results): ?>
           <?php
           // Property totalCount пусто пока не вызваны данные модели getModels(),

--- a/app/src/services/EmptySearchRequestExceptions.php
+++ b/app/src/services/EmptySearchRequestExceptions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\services;
+
+class EmptySearchRequestExceptions extends \Exception
+{
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}


### PR DESCRIPTION
Теперь кол-во записей в выдаче корректно.
Добавлены сообщения при неправильном вводе или пустом запросе, для улучшения производительности, и чтобы избежать показа 370к+ результатов при пустых запросах.