### PR TITLE
Изменено, чтобы убрать расстояние в 1px между nav и блоком

### DIFF
--- a/app/frontend/web/css/site.css
+++ b/app/frontend/web/css/site.css
@@ -207,7 +207,7 @@ p.summary {
 
 .search-block {
     position: sticky;
-    top: 56px;
+    top: 55px;
     z-index: 999;
 }
 


### PR DESCRIPTION
Это расстояние было заметно при прокрутке.