### PR TITLE
Добавлен виджет FollowLink.php

### DIFF
--- a/app/frontend/views/site/index.php
+++ b/app/frontend/views/site/index.php
@@ -14,6 +14,7 @@ use App\models\Comment;
 use App\repositories\Question\QuestionDataProvider;
 use frontend\widgets\question\CommentSummary;
 use frontend\widgets\Scroll\ScrollWidget;
+use frontend\widgets\search\FollowLink;
 use frontend\widgets\search\FollowQuestion;
 use kartik\daterange\DateRangePicker;
 use yii\bootstrap5\ActiveForm;
@@ -188,15 +189,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
                 <div class="card-footer d-flex justify-content-between">
                     <?= FollowQuestion::widget(['comment' => $comment, 'pagination' => $pagination]); ?>
-                    <?php
-                    $id = ($comment->type === 1) ? $comment->data_id : $comment->parent_id;
-                    $link = "https://фкт-алтай.рф/qa/question/view-" . $id;
-                    ?>
-                    <?= Html::a(
-                        'Перейти к комментарию на ФКТ',
-                        $link . "#:~:text=" . DateHelper::showDateFromTimestamp($comment->datetime),
-                        ['target' => '_blank', 'rel' => 'noopener noreferrer']
-                    ); ?>
+                    <?= FollowLink::widget(['comment' => $comment]); ?>
                 </div>
               </div>
             <?php endforeach; ?>

--- a/app/frontend/widgets/search/FollowLink.php
+++ b/app/frontend/widgets/search/FollowLink.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace frontend\widgets\search;
+
+use App\helpers\DateHelper;
+use App\models\Comment;
+use yii\base\Widget;
+use yii\bootstrap5\Html;
+
+class FollowLink extends Widget
+{
+    public Comment $comment;
+
+    public function run()
+    {
+        $id = ($this->comment->type === 1) ? $this->comment->data_id : $this->comment->parent_id;
+        $link = "https://фкт-алтай.рф/qa/question/view-" . $id;
+
+        $text = $this->comment->type === 1 ? "Перейти к вопросу на ФКТ" : "Перейти к комментарию на ФКТ";
+
+        return Html::a(
+            $text,
+            $link . "#:~:text=" . DateHelper::showDateFromTimestamp((int)$this->comment->datetime),
+            ['target' => '_blank', 'rel' => 'noopener noreferrer']
+        );
+    }
+}


### PR DESCRIPTION
Текст ссылки в результатах поиска отображается в зависимости от типа контента,
 для вопроса: Перейти к вопросу на ФКТ,
 для комментария: Перейти к комментарию на ФКТ.